### PR TITLE
Ci pipeline failures

### DIFF
--- a/cmd/forest/main.go
+++ b/cmd/forest/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// Plant trees
 	fmt.Println("Planting trees...")
-	
+
 	// Specific payment tree for Stripe webhooks
 	paymentTree := trees.NewPaymentTree(wind, river)
 	if err := paymentTree.Start(ctx); err != nil {
@@ -90,7 +90,7 @@ func main() {
 	}
 	defer paymentTree.Stop()
 	fmt.Println("  🌳 PaymentTree planted (watches: river.stripe.webhook)")
-	
+
 	// General tree that demonstrates extensibility
 	generalTree := trees.NewGeneralTree(wind, river)
 	if err := generalTree.Start(ctx); err != nil {
@@ -101,7 +101,7 @@ func main() {
 
 	// Awaken nims
 	fmt.Println("Awakening nims...")
-	
+
 	// Specific aftersales nim for payment events
 	afterSalesNim := nims.NewAfterSalesNim(wind, humus, soil)
 	if err := afterSalesNim.Start(ctx); err != nil {
@@ -109,7 +109,7 @@ func main() {
 	}
 	defer afterSalesNim.Stop()
 	fmt.Println("  🧚 AfterSalesNim awake (catches: payment.completed, payment.failed)")
-	
+
 	// General nim that demonstrates extensibility
 	generalNim := nims.NewGeneralNim(wind, humus, soil)
 	if err := generalNim.Start(ctx); err != nil {

--- a/internal/nims/general.go
+++ b/internal/nims/general.go
@@ -57,11 +57,11 @@ func (n *GeneralNim) Subjects() []string {
 // Start begins listening for leaves matching this nim's subjects.
 func (n *GeneralNim) Start(ctx context.Context) error {
 	n.ctx, n.cancel = context.WithCancel(ctx)
-	
+
 	log.Printf("[GeneralNim] 🧚 Starting general nim")
 	log.Printf("[GeneralNim] 💡 TIP: Create your own nim by copying this file!")
 	log.Printf("[GeneralNim]     Catching: %v", n.Subjects())
-	
+
 	// Register handlers for each subject
 	for _, subject := range n.Subjects() {
 		if err := n.Catch(subject, func(leaf core.Leaf) {
@@ -72,7 +72,7 @@ func (n *GeneralNim) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to catch %s: %w", subject, err)
 		}
 	}
-	
+
 	log.Printf("[GeneralNim] Started listening for general events")
 	return nil
 }
@@ -123,11 +123,11 @@ func (n *GeneralNim) handleDataReceived(ctx context.Context, leaf core.Leaf) err
 	// BUSINESS LOGIC EXAMPLE: Create a record of this data
 	recordID := fmt.Sprintf("data-record-%d", time.Now().Unix())
 	record := map[string]interface{}{
-		"id":         recordID,
-		"source":     source,
-		"data":       dataValue,
+		"id":          recordID,
+		"source":      source,
+		"data":        dataValue,
 		"received_at": time.Now().Format(time.RFC3339),
-		"processed":  true,
+		"processed":   true,
 	}
 
 	recordData, _ := json.Marshal(record)
@@ -169,11 +169,11 @@ func (n *GeneralNim) handleStatusUpdate(ctx context.Context, leaf core.Leaf) err
 	// BUSINESS LOGIC EXAMPLE: Update entity status in soil
 	if entityID != nil {
 		entityKey := fmt.Sprintf("entity-%v", entityID)
-		
+
 		// Try to read existing entity
 		existingData, revision, err := n.Dig(entityKey)
 		var entity map[string]interface{}
-		
+
 		if err == nil {
 			// Entity exists, update it
 			json.Unmarshal(existingData, &entity)
@@ -192,13 +192,13 @@ func (n *GeneralNim) handleStatusUpdate(ctx context.Context, leaf core.Leaf) err
 		}
 
 		entityData, _ := json.Marshal(entity)
-		
+
 		// Compost the change
 		action := "update"
 		if revision == 0 {
 			action = "create"
 		}
-		
+
 		slot, err := n.Compost(entityKey, action, entityData)
 		if err != nil {
 			return fmt.Errorf("failed to compost status update: %w", err)
@@ -219,14 +219,14 @@ func (n *GeneralNim) handleNotification(ctx context.Context, leaf core.Leaf) err
 	priority := event["priority"]
 	message := event["message"]
 	recipient := event["recipient"]
-	
+
 	log.Printf("[GeneralNim] 📧 Notification needed: [%v] to %v: %v", priority, recipient, message)
 
 	// BUSINESS LOGIC EXAMPLE: Route based on priority
 	if priority == "high" || priority == "urgent" {
 		// High priority - send immediately
 		log.Printf("[GeneralNim] 🚨 HIGH PRIORITY - sending immediately!")
-		
+
 		// Emit a leaf for immediate sending
 		if err := n.Leaf("notification.send.immediate", leaf.Data); err != nil {
 			log.Printf("[GeneralNim] ⚠️  Failed to emit immediate send: %v", err)
@@ -234,18 +234,18 @@ func (n *GeneralNim) handleNotification(ctx context.Context, leaf core.Leaf) err
 	} else {
 		// Normal priority - queue for batch sending
 		log.Printf("[GeneralNim] 📝 Normal priority - queuing for batch")
-		
+
 		// Create a queued notification record
 		notifID := fmt.Sprintf("notification-%d", time.Now().UnixNano())
 		queuedNotif := map[string]interface{}{
-			"id":         notifID,
-			"priority":   priority,
-			"message":    message,
-			"recipient":  recipient,
-			"queued_at":  time.Now().Format(time.RFC3339),
-			"sent":       false,
+			"id":        notifID,
+			"priority":  priority,
+			"message":   message,
+			"recipient": recipient,
+			"queued_at": time.Now().Format(time.RFC3339),
+			"sent":      false,
 		}
-		
+
 		notifData, _ := json.Marshal(queuedNotif)
 		slot, err := n.Compost(notifID, "create", notifData)
 		if err != nil {
@@ -260,7 +260,7 @@ func (n *GeneralNim) handleNotification(ctx context.Context, leaf core.Leaf) err
 // handleGeneralEvent demonstrates handling catch-all events
 func (n *GeneralNim) handleGeneralEvent(ctx context.Context, leaf core.Leaf) error {
 	log.Printf("[GeneralNim] 📋 Processing general event: %s", leaf.Subject)
-	
+
 	var event map[string]interface{}
 	if err := json.Unmarshal(leaf.Data, &event); err != nil {
 		log.Printf("[GeneralNim] ⚠️  Could not parse event data")
@@ -276,13 +276,13 @@ func (n *GeneralNim) handleGeneralEvent(ctx context.Context, leaf core.Leaf) err
 	// Could archive general events for analytics
 	eventID := fmt.Sprintf("event-%d", time.Now().UnixNano())
 	archiveData := map[string]interface{}{
-		"id":         eventID,
-		"subject":    leaf.Subject,
-		"source":     leaf.Source,
-		"timestamp":  time.Now().Format(time.RFC3339),
-		"data":       event,
+		"id":        eventID,
+		"subject":   leaf.Subject,
+		"source":    leaf.Source,
+		"timestamp": time.Now().Format(time.RFC3339),
+		"data":      event,
 	}
-	
+
 	archiveJSON, _ := json.Marshal(archiveData)
 	slot, err := n.Compost(eventID, "create", archiveJSON)
 	if err != nil {

--- a/internal/trees/general.go
+++ b/internal/trees/general.go
@@ -49,7 +49,7 @@ func (t *GeneralTree) Patterns() []string {
 // This implementation shows the basic structure of a tree's observation logic.
 func (t *GeneralTree) Start(ctx context.Context) error {
 	t.ctx, t.cancel = context.WithCancel(ctx)
-	
+
 	log.Printf("[GeneralTree] 🌳 Starting general tree - watching for river.general.>")
 	log.Printf("[GeneralTree] 💡 TIP: Create your own tree by copying this file!")
 	log.Printf("[GeneralTree]     Example patterns: river.api.>, river.crm.>, river.iot.>")
@@ -58,11 +58,11 @@ func (t *GeneralTree) Start(ctx context.Context) error {
 	err := t.Watch("river.general.>", func(data core.RiverData) {
 		t.parseGeneralData(data)
 	})
-	
+
 	if err != nil {
 		return fmt.Errorf("failed to start general tree: %w", err)
 	}
-	
+
 	log.Printf("[GeneralTree] Started watching for general events")
 	return nil
 }


### PR DESCRIPTION
## Description

This PR addresses and resolves CI failures caused by `go fmt` formatting issues. Specifically, it fixes trailing whitespace and indentation inconsistencies in `cmd/forest/main.go`, `internal/nims/general.go`, and `internal/trees/general.go` to comply with Go's standard formatting.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] CI/CD changes

## Testing

The following checks were performed locally:

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

Closes #

## Additional Context

The changes are purely cosmetic, focused on whitespace and indentation to align with `go fmt` requirements. No functional changes have been introduced. Local `go fmt`, `go vet`, and unit tests all pass after these adjustments, confirming the fix for the CI failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b3c7a8d-e633-4205-bd21-7a9e7c4a75cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b3c7a8d-e633-4205-bd21-7a9e7c4a75cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

