### PR TITLE
Ci failures investigation

### DIFF
--- a/internal/sources/ceremony.go
+++ b/internal/sources/ceremony.go
@@ -14,12 +14,12 @@ import (
 
 // CeremonySourceConfig configures a ceremony source.
 type CeremonySourceConfig struct {
-	Name      string            // Source name (unique identifier)
-	Interval  time.Duration     // How often to trigger (e.g., 30s, 5m, 1h)
-	Publishes string            // River subject to publish to
-	Payload   map[string]any    // Static payload (optional)
-	Script    string            // Lua script path for dynamic payload (optional)
-	Hz        int               // WindWaker frequency (default: 90)
+	Name      string         // Source name (unique identifier)
+	Interval  time.Duration  // How often to trigger (e.g., 30s, 5m, 1h)
+	Publishes string         // River subject to publish to
+	Payload   map[string]any // Static payload (optional)
+	Script    string         // Lua script path for dynamic payload (optional)
+	Hz        int            // WindWaker frequency (default: 90)
 }
 
 // CeremonySource triggers events at intervals by counting WindWaker beats.
@@ -44,13 +44,13 @@ type CeremonySource struct {
 
 // CeremonyPayload is the payload structure sent to the River.
 type CeremonyPayload struct {
-	Source      string         `json:"source"`
-	Trigger     uint64         `json:"trigger"`     // Trigger count
-	Interval    string         `json:"interval"`    // Configured interval
-	Timestamp   time.Time      `json:"timestamp"`
-	Payload     map[string]any `json:"payload,omitempty"` // Static payload data
-	BeatCount   uint64         `json:"beat_count"`        // Beats since last trigger
-	Uptime      string         `json:"uptime"`            // Source uptime
+	Source    string         `json:"source"`
+	Trigger   uint64         `json:"trigger"`  // Trigger count
+	Interval  string         `json:"interval"` // Configured interval
+	Timestamp time.Time      `json:"timestamp"`
+	Payload   map[string]any `json:"payload,omitempty"` // Static payload data
+	BeatCount uint64         `json:"beat_count"`        // Beats since last trigger
+	Uptime    string         `json:"uptime"`            // Source uptime
 }
 
 // Beat matches the WindWaker's beat structure.

--- a/internal/sources/ceremony_test.go
+++ b/internal/sources/ceremony_test.go
@@ -33,11 +33,11 @@ func TestCeremonySource_BeatsPerTrigger(t *testing.T) {
 		hz       int
 		expected uint64
 	}{
-		{30 * time.Second, 90, 2700},    // 30s * 90Hz = 2700 beats
-		{time.Minute, 90, 5400},         // 60s * 90Hz = 5400 beats
-		{time.Hour, 90, 324000},         // 3600s * 90Hz = 324000 beats
-		{5 * time.Minute, 90, 27000},    // 300s * 90Hz = 27000 beats
-		{10 * time.Second, 100, 1000},   // 10s * 100Hz = 1000 beats
+		{30 * time.Second, 90, 2700},  // 30s * 90Hz = 2700 beats
+		{time.Minute, 90, 5400},       // 60s * 90Hz = 5400 beats
+		{time.Hour, 90, 324000},       // 3600s * 90Hz = 324000 beats
+		{5 * time.Minute, 90, 27000},  // 300s * 90Hz = 27000 beats
+		{10 * time.Second, 100, 1000}, // 10s * 100Hz = 1000 beats
 	}
 
 	for _, tt := range tests {

--- a/internal/sources/factory.go
+++ b/internal/sources/factory.go
@@ -33,13 +33,13 @@ type SourceConfig struct {
 	Headers []string `yaml:"headers,omitempty"`
 
 	// HTTP Poll fields
-	URL      string            `yaml:"url,omitempty"`
-	Method   string            `yaml:"method,omitempty"`
-	Interval string            `yaml:"interval,omitempty"` // Duration string (e.g., "5m", "1h")
+	URL        string            `yaml:"url,omitempty"`
+	Method     string            `yaml:"method,omitempty"`
+	Interval   string            `yaml:"interval,omitempty"` // Duration string (e.g., "5m", "1h")
 	ReqHeaders map[string]string `yaml:"request_headers,omitempty"`
-	Body     string            `yaml:"body,omitempty"`
-	Cursor   *CursorConfig     `yaml:"cursor,omitempty"`
-	Timeout  string            `yaml:"timeout,omitempty"`
+	Body       string            `yaml:"body,omitempty"`
+	Cursor     *CursorConfig     `yaml:"cursor,omitempty"`
+	Timeout    string            `yaml:"timeout,omitempty"`
 
 	// Ceremony fields
 	Payload map[string]any `yaml:"payload,omitempty"`

--- a/internal/sources/poll.go
+++ b/internal/sources/poll.go
@@ -41,12 +41,12 @@ type PollSource struct {
 	client *http.Client
 	cursor string // Current cursor value
 
-	mu       sync.Mutex
-	running  bool
-	stopCh   chan struct{}
-	wg       sync.WaitGroup
-	lastPoll time.Time
-	pollCount uint64
+	mu         sync.Mutex
+	running    bool
+	stopCh     chan struct{}
+	wg         sync.WaitGroup
+	lastPoll   time.Time
+	pollCount  uint64
 	errorCount uint64
 }
 

--- a/pkg/runtime/api.go
+++ b/pkg/runtime/api.go
@@ -151,17 +151,17 @@ func (api *API) handleListSources(w http.ResponseWriter, r *http.Request) {
 
 func (api *API) handleAddSource(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name      string            `json:"name"`
-		Type      string            `json:"type"`
-		Publishes string            `json:"publishes"`
-		Path      string            `json:"path,omitempty"`
-		Secret    string            `json:"secret,omitempty"`
-		Headers   []string          `json:"headers,omitempty"`
-		URL       string            `json:"url,omitempty"`
-		Method    string            `json:"method,omitempty"`
-		Interval  string            `json:"interval,omitempty"`
+		Name       string            `json:"name"`
+		Type       string            `json:"type"`
+		Publishes  string            `json:"publishes"`
+		Path       string            `json:"path,omitempty"`
+		Secret     string            `json:"secret,omitempty"`
+		Headers    []string          `json:"headers,omitempty"`
+		URL        string            `json:"url,omitempty"`
+		Method     string            `json:"method,omitempty"`
+		Interval   string            `json:"interval,omitempty"`
 		ReqHeaders map[string]string `json:"request_headers,omitempty"`
-		Payload   map[string]any    `json:"payload,omitempty"`
+		Payload    map[string]any    `json:"payload,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/pkg/runtime/forest.go
+++ b/pkg/runtime/forest.go
@@ -15,17 +15,17 @@ import (
 // Forest is the main runtime that manages all Sources, Trees, TreeHouses and Nims.
 // It uses Wind for all pub/sub operations.
 type Forest struct {
-	config     *Config
-	wind       *core.Wind
-	river      *core.River // Optional: for Trees and Sources (requires JetStream)
-	humus      *core.Humus // Optional: for state tracking
-	brain      brain.Brain
+	config *Config
+	wind   *core.Wind
+	river  *core.River // Optional: for Trees and Sources (requires JetStream)
+	humus  *core.Humus // Optional: for state tracking
+	brain  brain.Brain
 
 	// Components
-	sources       map[string]core.Source
-	trees         map[string]*Tree
-	treehouses    map[string]*TreeHouse
-	nims          map[string]*Nim
+	sources    map[string]core.Source
+	trees      map[string]*Tree
+	treehouses map[string]*TreeHouse
+	nims       map[string]*Nim
 
 	// HTTP server for webhook sources
 	webhookServer *sources.WebhookServer


### PR DESCRIPTION
## Description

Fixed CI failure caused by inconsistent Go struct field alignment. The changes were applied by running `gofmt -s -w .` to ensure all affected files conform to standard Go formatting.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] CI/CD changes

## Testing

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linting passes (`make lint`)
- [x] Code is formatted (`make fmt`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

Closes #(issue number)

## Additional Context

The following files had formatting issues related to struct field alignment:
- `internal/sources/ceremony.go`
- `internal/sources/ceremony_test.go`
- `internal/sources/factory.go`
- `internal/sources/poll.go`
- `pkg/runtime/api.go`
- `pkg/runtime/forest.go`

---
<a href="https://cursor.com/background-agent?bcId=bc-22ed2d9a-4912-4cc7-856c-895b38764990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22ed2d9a-4912-4cc7-856c-895b38764990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

