### PR TITLE
Review plans and test nimsforest locally

### DIFF
--- a/docs/plans/filesystem-soil-integration.md
+++ b/docs/plans/filesystem-soil-integration.md
@@ -1,6 +1,6 @@
 # Bedrock: Persistent Storage Foundation
 
-**Status**: 📋 Planned
+**Status**: 🚧 In Progress (Core Implementation Complete)
 **Goal**: Establish Bedrocks as the persistent storage layer beneath Soil
 
 ## Core Metaphor
@@ -543,14 +543,30 @@ bedrocks:
 
 ## Success Criteria
 
-- [ ] Unix bedrock implemented with fsnotify
-- [ ] Git bedrock implemented with PR workflow
+- [x] Unix bedrock implemented with fsnotify
+- [x] Git bedrock implemented with PR workflow
 - [ ] BedrockReadTreehouse builds tree/index in Soil
 - [ ] BedrockWriteTreehouse handles persist.* with locking
 - [ ] Cluster recovery rebuilds Soil from bedrocks
-- [ ] Tree regeneration batched for performance
+- [x] Tree regeneration batched for performance
 - [ ] Locks prevent concurrent writes
 - [ ] PR locks held until human approval
+
+## Implementation Progress
+
+### Completed (Phase 1)
+- Core `Bedrock` interface with read/write operations
+- `UnixBedrock` - filesystem access with fsnotify watching
+- `GitBedrockImpl` - git repository with commit and PR workflows
+- Forest integration - bedrocks start/stop with forest lifecycle
+- Configuration support - YAML config for bedrocks
+- Comprehensive test suite
+
+### Remaining (Phase 2)
+- `BedrockReadTreehouse` - Soil indexing from bedrock events
+- `BedrockWriteTreehouse` - Persist operations with distributed locking
+- Cluster recovery from bedrock state
+- External bedrocks (Google Drive, S3) - future
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,8 @@ module github.com/yourusername/nimsforest
 
 go 1.24.0
 
-toolchain go1.24.11
-
 require (
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/nats-io/nats-server/v2 v2.12.3
 	github.com/nats-io/nats.go v1.48.0
 	github.com/shirou/gopsutil/v3 v3.24.5

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/antithesishq/antithesis-sdk-go v0.5.0-default-no-op h1:Ucf+QxEKMbPogR
 github.com/antithesishq/antithesis-sdk-go v0.5.0-default-no-op/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/pkg/runtime/bedrock.go
+++ b/pkg/runtime/bedrock.go
@@ -1,0 +1,243 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Bedrock represents a persistent storage layer beneath Soil.
+// While Soil (KV store) provides fast ephemeral access, Bedrock
+// provides persistent storage that survives restarts.
+//
+// Bedrock is always the source of truth. Soil can be rebuilt from Bedrock.
+type Bedrock interface {
+	// Name returns the bedrock's name for identification
+	Name() string
+
+	// Type returns the bedrock type (git, unix, google_drive, s3)
+	Type() string
+
+	// Lifecycle
+	Start(ctx context.Context) error
+	Stop() error
+
+	// Read operations
+	List(path string) ([]FileInfo, error)
+	Read(path string) ([]byte, error)
+	Stat(path string) (*FileInfo, error)
+	Tree(maxDepth int) (string, error)
+
+	// Write operations (may return ErrReadOnly)
+	Write(path string, content []byte) error
+	Delete(path string) error
+	Move(from, to string) error
+
+	// Capabilities
+	IsReadOnly() bool
+	SupportsWatch() bool
+}
+
+// FileInfo provides metadata about a file in a Bedrock.
+type FileInfo struct {
+	Path        string    `json:"path"`
+	Name        string    `json:"name"`
+	Size        int64     `json:"size"`
+	Modified    time.Time `json:"modified"`
+	IsDir       bool      `json:"is_dir"`
+	ContentHash string    `json:"content_hash,omitempty"`
+	MimeType    string    `json:"mime_type,omitempty"`
+}
+
+// BedrockManifest provides metadata about a mounted bedrock.
+type BedrockManifest struct {
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	Root      string    `json:"root"`
+	FileCount int       `json:"file_count"`
+	TotalSize int64     `json:"total_size"`
+	LastScan  time.Time `json:"last_scan"`
+
+	// Git-specific fields
+	Remote string `json:"remote,omitempty"`
+	Branch string `json:"branch,omitempty"`
+}
+
+// BedrockLock represents a distributed lock on a file.
+type BedrockLock struct {
+	Holder   string     `json:"holder"`
+	Type     LockType   `json:"type"`
+	Acquired time.Time  `json:"acquired"`
+	TTL      int        `json:"ttl,omitempty"` // seconds, 0 for pending_pr
+	PR       string     `json:"pr,omitempty"`  // PR reference for pending_pr type
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// LockType indicates the type of lock held.
+type LockType string
+
+const (
+	// LockTypeWrite is a short-lived lock for active writes.
+	LockTypeWrite LockType = "write"
+
+	// LockTypePendingPR is held until PR is merged/closed.
+	LockTypePendingPR LockType = "pending_pr"
+)
+
+// IsExpired returns true if the lock has expired.
+func (l *BedrockLock) IsExpired() bool {
+	if l.Type == LockTypePendingPR {
+		return false // PR locks don't expire
+	}
+	if l.ExpiresAt != nil {
+		return time.Now().After(*l.ExpiresAt)
+	}
+	if l.TTL > 0 {
+		return time.Since(l.Acquired) > time.Duration(l.TTL)*time.Second
+	}
+	return false
+}
+
+// BedrockEvent represents a change event from a bedrock.
+type BedrockEvent struct {
+	Bedrock   string         `json:"bedrock"`
+	Type      BedrockEventType `json:"type"`
+	Path      string         `json:"path,omitempty"`
+	Timestamp time.Time      `json:"timestamp"`
+	FileInfo  *FileInfo      `json:"file_info,omitempty"`
+}
+
+// BedrockEventType indicates the type of bedrock event.
+type BedrockEventType string
+
+const (
+	BedrockEventMounted      BedrockEventType = "mounted"
+	BedrockEventUnmounted    BedrockEventType = "unmounted"
+	BedrockEventFileCreated  BedrockEventType = "file.created"
+	BedrockEventFileModified BedrockEventType = "file.modified"
+	BedrockEventFileDeleted  BedrockEventType = "file.deleted"
+	BedrockEventFileMoved    BedrockEventType = "file.moved"
+)
+
+// PersistRequest represents a request to persist data to bedrock.
+type PersistRequest struct {
+	Bedrock string `json:"bedrock"`
+	Path    string `json:"path"`
+	Content []byte `json:"content,omitempty"`
+	Message string `json:"message,omitempty"` // Commit message for git
+}
+
+// PersistResult represents the result of a persist operation.
+type PersistResult struct {
+	Bedrock string          `json:"bedrock"`
+	Path    string          `json:"path"`
+	Status  PersistStatus   `json:"status"`
+	Error   string          `json:"error,omitempty"`
+	PR      string          `json:"pr,omitempty"` // PR URL for pending status
+}
+
+// PersistStatus indicates the status of a persist operation.
+type PersistStatus string
+
+const (
+	PersistStatusComplete PersistStatus = "complete"
+	PersistStatusPending  PersistStatus = "pending"  // Awaiting approval
+	PersistStatusRejected PersistStatus = "rejected" // PR was closed
+	PersistStatusFailed   PersistStatus = "failed"
+)
+
+// Common errors
+var (
+	ErrReadOnly       = fmt.Errorf("bedrock is read-only")
+	ErrNotFound       = fmt.Errorf("file not found")
+	ErrAlreadyExists  = fmt.Errorf("file already exists")
+	ErrLocked         = fmt.Errorf("file is locked")
+	ErrAwaitingPR     = fmt.Errorf("file is locked pending PR approval")
+	ErrInvalidPath    = fmt.Errorf("invalid path")
+	ErrBedrockStopped = fmt.Errorf("bedrock is not running")
+)
+
+// LockedError provides details about a lock conflict.
+type LockedError struct {
+	Holder string
+	Lock   *BedrockLock
+}
+
+func (e *LockedError) Error() string {
+	if e.Lock != nil && e.Lock.Type == LockTypePendingPR {
+		return fmt.Sprintf("file locked pending PR approval: %s (holder: %s)", e.Lock.PR, e.Holder)
+	}
+	return fmt.Sprintf("file is locked by %s", e.Holder)
+}
+
+// Soil key patterns for bedrock data
+const (
+	// SoilKeyBedrockTree is the pattern for tree documents
+	// Format: bedrock:{name}:tree
+	SoilKeyBedrockTree = "bedrock:%s:tree"
+
+	// SoilKeyBedrockManifest is the pattern for manifests
+	// Format: bedrock:{name}:manifest
+	SoilKeyBedrockManifest = "bedrock:%s:manifest"
+
+	// SoilKeyBedrockFile is the pattern for file metadata
+	// Format: bedrock:{name}:file:{path}
+	SoilKeyBedrockFile = "bedrock:%s:file:%s"
+
+	// SoilKeyBedrockLock is the pattern for file locks
+	// Format: bedrock:{name}:lock:{path}
+	SoilKeyBedrockLock = "bedrock:%s:lock:%s"
+
+	// SoilKeyBedrockCache is the pattern for cached file content
+	// Format: cache:{name}:{path}
+	SoilKeyBedrockCache = "cache:%s:%s"
+)
+
+// NATS subject patterns for bedrock events
+const (
+	// SubjectBedrockEvents is the pattern for bedrock events
+	// Format: bedrock.{name}.{event_type}
+	SubjectBedrockEvents = "bedrock.%s.%s"
+
+	// SubjectPersistRequest is the pattern for persist requests
+	// Format: persist.{name}.request
+	SubjectPersistRequest = "persist.%s.request"
+
+	// SubjectPersistResult is the pattern for persist results
+	// Format: persist.{name}.{status}
+	SubjectPersistResult = "persist.%s.%s"
+
+	// SubjectIndexUpdated is emitted when bedrock index is updated
+	// Format: index.{name}.updated
+	SubjectIndexUpdated = "index.%s.updated"
+)
+
+// BedrockWatcher is an optional interface for bedrocks that support
+// watching for file changes.
+type BedrockWatcher interface {
+	Bedrock
+
+	// Watch starts watching for file changes and calls the handler
+	// for each change event.
+	Watch(ctx context.Context, handler func(BedrockEvent)) error
+}
+
+// GitBedrock is an optional interface for git-based bedrocks.
+type GitBedrock interface {
+	Bedrock
+
+	// WriteMode returns "commit" or "pull_request"
+	WriteMode() string
+
+	// CreatePR creates a pull request for the given changes
+	CreatePR(ctx context.Context, branch, title, body string) (prURL string, err error)
+
+	// Sync syncs with the remote repository
+	Sync(ctx context.Context) error
+
+	// CurrentBranch returns the current branch name
+	CurrentBranch() string
+
+	// Remote returns the remote URL
+	Remote() string
+}

--- a/pkg/runtime/bedrock_git.go
+++ b/pkg/runtime/bedrock_git.go
@@ -1,0 +1,496 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GitBedrock provides git repository access as a bedrock.
+// It extends UnixBedrock with git operations and PR workflow support.
+type GitBedrockImpl struct {
+	*UnixBedrock
+	remote    string
+	branch    string
+	writeMode string // "commit" or "pull_request"
+	prConfig  *PRConfig
+
+	gitMu sync.Mutex // Serialize git operations
+}
+
+// PRConfig configures pull request creation.
+type PRConfig struct {
+	BaseBranch   string   `yaml:"base_branch"`
+	BranchPrefix string   `yaml:"branch_prefix"`
+	Reviewers    []string `yaml:"reviewers,omitempty"`
+	Labels       []string `yaml:"labels,omitempty"`
+}
+
+// GitBedrockConfig configures a Git bedrock.
+type GitBedrockConfig struct {
+	Name      string    `yaml:"name"`
+	Path      string    `yaml:"path"`
+	Remote    string    `yaml:"remote,omitempty"`
+	Branch    string    `yaml:"branch,omitempty"`
+	WriteMode string    `yaml:"write_mode,omitempty"` // "commit" or "pull_request"
+	PRConfig  *PRConfig `yaml:"pr_config,omitempty"`
+	ReadOnly  bool      `yaml:"readonly,omitempty"`
+}
+
+// NewGitBedrock creates a new Git bedrock.
+func NewGitBedrock(cfg GitBedrockConfig) (*GitBedrockImpl, error) {
+	// Validate write mode
+	if cfg.WriteMode == "" {
+		cfg.WriteMode = "commit"
+	}
+	if cfg.WriteMode != "commit" && cfg.WriteMode != "pull_request" {
+		return nil, fmt.Errorf("invalid write_mode: %s (use commit or pull_request)", cfg.WriteMode)
+	}
+
+	// PR mode requires pr_config
+	if cfg.WriteMode == "pull_request" && cfg.PRConfig == nil {
+		cfg.PRConfig = &PRConfig{
+			BaseBranch:   "main",
+			BranchPrefix: "nim/",
+		}
+	}
+
+	// Default branch
+	if cfg.Branch == "" {
+		cfg.Branch = "main"
+	}
+
+	// Resolve path
+	absPath, err := filepath.Abs(cfg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	// Check if it's a git repository
+	if _, err := os.Stat(filepath.Join(absPath, ".git")); err != nil {
+		if os.IsNotExist(err) {
+			// Try to initialize or clone
+			if cfg.Remote != "" {
+				if err := cloneRepo(cfg.Remote, absPath, cfg.Branch); err != nil {
+					return nil, fmt.Errorf("failed to clone repository: %w", err)
+				}
+			} else {
+				return nil, fmt.Errorf("path is not a git repository: %s", absPath)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to check .git directory: %w", err)
+		}
+	}
+
+	// Create underlying Unix bedrock
+	unix, err := NewUnixBedrock(UnixBedrockConfig{
+		Name:     cfg.Name,
+		Path:     absPath,
+		ReadOnly: cfg.ReadOnly,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &GitBedrockImpl{
+		UnixBedrock: unix,
+		remote:      cfg.Remote,
+		branch:      cfg.Branch,
+		writeMode:   cfg.WriteMode,
+		prConfig:    cfg.PRConfig,
+	}, nil
+}
+
+// Type returns "git".
+func (b *GitBedrockImpl) Type() string {
+	return "git"
+}
+
+// Start starts the bedrock, syncing with remote first.
+func (b *GitBedrockImpl) Start(ctx context.Context) error {
+	// Sync with remote if configured
+	if b.remote != "" {
+		if err := b.Sync(ctx); err != nil {
+			log.Printf("[Bedrock:%s] Warning: failed to sync with remote: %v", b.name, err)
+		}
+	}
+
+	return b.UnixBedrock.Start(ctx)
+}
+
+// WriteMode returns the write mode ("commit" or "pull_request").
+func (b *GitBedrockImpl) WriteMode() string {
+	return b.writeMode
+}
+
+// CurrentBranch returns the current branch name.
+func (b *GitBedrockImpl) CurrentBranch() string {
+	return b.branch
+}
+
+// Remote returns the remote URL.
+func (b *GitBedrockImpl) Remote() string {
+	return b.remote
+}
+
+// Sync fetches and pulls from the remote repository.
+func (b *GitBedrockImpl) Sync(ctx context.Context) error {
+	b.gitMu.Lock()
+	defer b.gitMu.Unlock()
+
+	if b.remote == "" {
+		return nil
+	}
+
+	// Fetch from origin
+	if _, err := b.git(ctx, "fetch", "origin", b.branch); err != nil {
+		return fmt.Errorf("failed to fetch: %w", err)
+	}
+
+	// Reset to origin/branch (fast-forward)
+	if _, err := b.git(ctx, "reset", "--hard", fmt.Sprintf("origin/%s", b.branch)); err != nil {
+		return fmt.Errorf("failed to reset to origin/%s: %w", b.branch, err)
+	}
+
+	log.Printf("[Bedrock:%s] Synced with origin/%s", b.name, b.branch)
+	return nil
+}
+
+// Write writes content and optionally commits or creates a PR.
+func (b *GitBedrockImpl) Write(path string, content []byte) error {
+	// First write the file using Unix bedrock
+	if err := b.UnixBedrock.Write(path, content); err != nil {
+		return err
+	}
+
+	// If not in commit or PR mode, just return
+	if b.writeMode == "" || b.readonly {
+		return nil
+	}
+
+	return nil // Commit/PR happens in WriteAndCommit
+}
+
+// WriteAndCommit writes content and commits with a message.
+func (b *GitBedrockImpl) WriteAndCommit(ctx context.Context, path string, content []byte, message string) error {
+	b.gitMu.Lock()
+	defer b.gitMu.Unlock()
+
+	// Write the file
+	if err := b.UnixBedrock.Write(path, content); err != nil {
+		return err
+	}
+
+	// Stage the file
+	if _, err := b.git(ctx, "add", path); err != nil {
+		return fmt.Errorf("failed to stage file: %w", err)
+	}
+
+	// Commit
+	if message == "" {
+		message = fmt.Sprintf("Update %s", path)
+	}
+	if _, err := b.git(ctx, "commit", "-m", message); err != nil {
+		// Check if nothing to commit
+		if strings.Contains(err.Error(), "nothing to commit") {
+			return nil
+		}
+		return fmt.Errorf("failed to commit: %w", err)
+	}
+
+	log.Printf("[Bedrock:%s] Committed: %s", b.name, message)
+
+	// Push if remote is configured
+	if b.remote != "" {
+		if _, err := b.git(ctx, "push", "origin", b.branch); err != nil {
+			return fmt.Errorf("failed to push: %w", err)
+		}
+		log.Printf("[Bedrock:%s] Pushed to origin/%s", b.name, b.branch)
+	}
+
+	return nil
+}
+
+// CreatePR creates a pull request for the given changes.
+func (b *GitBedrockImpl) CreatePR(ctx context.Context, branchName, title, body string) (string, error) {
+	b.gitMu.Lock()
+	defer b.gitMu.Unlock()
+
+	if b.prConfig == nil {
+		return "", fmt.Errorf("PR config not set")
+	}
+
+	baseBranch := b.prConfig.BaseBranch
+	if baseBranch == "" {
+		baseBranch = b.branch
+	}
+
+	// Create a new branch
+	prBranch := b.prConfig.BranchPrefix + branchName
+	if _, err := b.git(ctx, "checkout", "-b", prBranch); err != nil {
+		return "", fmt.Errorf("failed to create branch: %w", err)
+	}
+
+	// Push the branch
+	if _, err := b.git(ctx, "push", "-u", "origin", prBranch); err != nil {
+		// Switch back to main branch on failure
+		b.git(ctx, "checkout", baseBranch)
+		b.git(ctx, "branch", "-D", prBranch)
+		return "", fmt.Errorf("failed to push branch: %w", err)
+	}
+
+	// Create PR using gh CLI
+	args := []string{"pr", "create",
+		"--base", baseBranch,
+		"--head", prBranch,
+		"--title", title,
+		"--body", body,
+	}
+
+	// Add reviewers
+	for _, reviewer := range b.prConfig.Reviewers {
+		args = append(args, "--reviewer", reviewer)
+	}
+
+	// Add labels
+	for _, label := range b.prConfig.Labels {
+		args = append(args, "--label", label)
+	}
+
+	output, err := b.gh(ctx, args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to create PR: %w", err)
+	}
+
+	prURL := strings.TrimSpace(output)
+
+	// Switch back to main branch
+	if _, err := b.git(ctx, "checkout", baseBranch); err != nil {
+		log.Printf("[Bedrock:%s] Warning: failed to switch back to %s: %v", b.name, baseBranch, err)
+	}
+
+	log.Printf("[Bedrock:%s] Created PR: %s", b.name, prURL)
+	return prURL, nil
+}
+
+// WriteWithPR writes content and creates a PR for review.
+func (b *GitBedrockImpl) WriteWithPR(ctx context.Context, path string, content []byte, title, body string) (string, error) {
+	b.gitMu.Lock()
+	defer b.gitMu.Unlock()
+
+	if b.prConfig == nil {
+		return "", fmt.Errorf("PR config not set")
+	}
+
+	baseBranch := b.prConfig.BaseBranch
+	if baseBranch == "" {
+		baseBranch = b.branch
+	}
+
+	// Generate branch name from path
+	safePath := strings.ReplaceAll(path, "/", "-")
+	safePath = strings.ReplaceAll(safePath, ".", "-")
+	branchName := fmt.Sprintf("update-%s-%d", safePath, time.Now().Unix())
+	prBranch := b.prConfig.BranchPrefix + branchName
+
+	// Create a new branch
+	if _, err := b.git(ctx, "checkout", "-b", prBranch); err != nil {
+		return "", fmt.Errorf("failed to create branch: %w", err)
+	}
+
+	// Write the file (without lock since we already hold it)
+	fullPath := filepath.Join(b.root, path)
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		b.git(ctx, "checkout", baseBranch)
+		b.git(ctx, "branch", "-D", prBranch)
+		return "", fmt.Errorf("failed to create directory: %w", err)
+	}
+	if err := os.WriteFile(fullPath, content, 0644); err != nil {
+		b.git(ctx, "checkout", baseBranch)
+		b.git(ctx, "branch", "-D", prBranch)
+		return "", fmt.Errorf("failed to write file: %w", err)
+	}
+
+	// Stage and commit
+	if _, err := b.git(ctx, "add", path); err != nil {
+		b.git(ctx, "checkout", baseBranch)
+		b.git(ctx, "branch", "-D", prBranch)
+		return "", fmt.Errorf("failed to stage file: %w", err)
+	}
+
+	commitMsg := title
+	if commitMsg == "" {
+		commitMsg = fmt.Sprintf("Update %s", path)
+	}
+	if _, err := b.git(ctx, "commit", "-m", commitMsg); err != nil {
+		b.git(ctx, "checkout", baseBranch)
+		b.git(ctx, "branch", "-D", prBranch)
+		return "", fmt.Errorf("failed to commit: %w", err)
+	}
+
+	// Push the branch
+	if _, err := b.git(ctx, "push", "-u", "origin", prBranch); err != nil {
+		b.git(ctx, "checkout", baseBranch)
+		b.git(ctx, "branch", "-D", prBranch)
+		return "", fmt.Errorf("failed to push branch: %w", err)
+	}
+
+	// Create PR using gh CLI
+	args := []string{"pr", "create",
+		"--base", baseBranch,
+		"--head", prBranch,
+		"--title", title,
+		"--body", body,
+	}
+
+	for _, reviewer := range b.prConfig.Reviewers {
+		args = append(args, "--reviewer", reviewer)
+	}
+	for _, label := range b.prConfig.Labels {
+		args = append(args, "--label", label)
+	}
+
+	output, err := b.gh(ctx, args...)
+	if err != nil {
+		// PR creation failed, but changes are pushed
+		b.git(ctx, "checkout", baseBranch)
+		return "", fmt.Errorf("failed to create PR (branch %s pushed): %w", prBranch, err)
+	}
+
+	prURL := strings.TrimSpace(output)
+
+	// Switch back to main branch
+	if _, err := b.git(ctx, "checkout", baseBranch); err != nil {
+		log.Printf("[Bedrock:%s] Warning: failed to switch back to %s: %v", b.name, baseBranch, err)
+	}
+
+	log.Printf("[Bedrock:%s] Created PR: %s", b.name, prURL)
+	return prURL, nil
+}
+
+// CheckPRStatus checks the status of a pull request.
+func (b *GitBedrockImpl) CheckPRStatus(ctx context.Context, prURL string) (string, error) {
+	// Extract PR number from URL
+	parts := strings.Split(prURL, "/")
+	if len(parts) < 1 {
+		return "", fmt.Errorf("invalid PR URL")
+	}
+	prNumber := parts[len(parts)-1]
+
+	output, err := b.gh(ctx, "pr", "view", prNumber, "--json", "state", "--jq", ".state")
+	if err != nil {
+		return "", fmt.Errorf("failed to check PR status: %w", err)
+	}
+
+	return strings.TrimSpace(strings.ToLower(output)), nil
+}
+
+// Manifest returns the bedrock manifest with git info.
+func (b *GitBedrockImpl) Manifest() (*BedrockManifest, error) {
+	manifest, err := b.UnixBedrock.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	manifest.Type = "git"
+	manifest.Remote = b.remote
+	manifest.Branch = b.branch
+
+	return manifest, nil
+}
+
+// git executes a git command in the repository.
+func (b *GitBedrockImpl) git(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = b.root
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%s: %s", err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+// gh executes a gh CLI command.
+func (b *GitBedrockImpl) gh(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = b.root
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%s: %s", err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+// cloneRepo clones a repository.
+func cloneRepo(remote, path, branch string) error {
+	args := []string{"clone", "--branch", branch, "--single-branch", remote, path}
+	cmd := exec.Command("git", args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %s", err, stderr.String())
+	}
+
+	return nil
+}
+
+// GetCommitHash returns the current commit hash.
+func (b *GitBedrockImpl) GetCommitHash(ctx context.Context) (string, error) {
+	output, err := b.git(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+// GetFileHistory returns the git log for a file.
+func (b *GitBedrockImpl) GetFileHistory(ctx context.Context, path string, limit int) (string, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	output, err := b.git(ctx, "log", fmt.Sprintf("-n%d", limit), "--oneline", "--", path)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+// GetDiff returns the diff of uncommitted changes.
+func (b *GitBedrockImpl) GetDiff(ctx context.Context) (string, error) {
+	output, err := b.git(ctx, "diff", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+// HasUncommittedChanges returns true if there are uncommitted changes.
+func (b *GitBedrockImpl) HasUncommittedChanges(ctx context.Context) (bool, error) {
+	output, err := b.git(ctx, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(output) != "", nil
+}

--- a/pkg/runtime/bedrock_test.go
+++ b/pkg/runtime/bedrock_test.go
@@ -1,0 +1,524 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestUnixBedrock_Basic(t *testing.T) {
+	// Create temp directory for testing
+	tmpDir, err := os.MkdirTemp("", "bedrock-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create bedrock
+	br, err := NewUnixBedrock(UnixBedrockConfig{
+		Name: "test",
+		Path: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bedrock: %v", err)
+	}
+
+	// Test basic properties
+	if br.Name() != "test" {
+		t.Errorf("Expected name 'test', got '%s'", br.Name())
+	}
+	if br.Type() != "unix" {
+		t.Errorf("Expected type 'unix', got '%s'", br.Type())
+	}
+	if br.IsReadOnly() {
+		t.Error("Expected bedrock to be writable")
+	}
+	if !br.SupportsWatch() {
+		t.Error("Expected bedrock to support watching")
+	}
+
+	// Start the bedrock
+	ctx := context.Background()
+	if err := br.Start(ctx); err != nil {
+		t.Fatalf("Failed to start bedrock: %v", err)
+	}
+	defer br.Stop()
+
+	// Test write
+	testContent := []byte("Hello, Bedrock!")
+	if err := br.Write("test.txt", testContent); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	// Test read
+	content, err := br.Read("test.txt")
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+	if string(content) != string(testContent) {
+		t.Errorf("Expected content '%s', got '%s'", testContent, content)
+	}
+
+	// Test stat
+	info, err := br.Stat("test.txt")
+	if err != nil {
+		t.Fatalf("Failed to stat file: %v", err)
+	}
+	if info.Name != "test.txt" {
+		t.Errorf("Expected name 'test.txt', got '%s'", info.Name)
+	}
+	if info.Size != int64(len(testContent)) {
+		t.Errorf("Expected size %d, got %d", len(testContent), info.Size)
+	}
+
+	// Test list
+	files, err := br.List("")
+	if err != nil {
+		t.Fatalf("Failed to list files: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("Expected 1 file, got %d", len(files))
+	}
+
+	// Test tree
+	tree, err := br.Tree(5)
+	if err != nil {
+		t.Fatalf("Failed to get tree: %v", err)
+	}
+	if tree == "" {
+		t.Error("Expected non-empty tree")
+	}
+
+	// Test delete
+	if err := br.Delete("test.txt"); err != nil {
+		t.Fatalf("Failed to delete file: %v", err)
+	}
+
+	// Verify deleted
+	if _, err := br.Read("test.txt"); err != ErrNotFound {
+		t.Error("Expected ErrNotFound after delete")
+	}
+}
+
+func TestUnixBedrock_ReadOnly(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bedrock-test-readonly-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	br, err := NewUnixBedrock(UnixBedrockConfig{
+		Name:     "test-readonly",
+		Path:     tmpDir,
+		ReadOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bedrock: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := br.Start(ctx); err != nil {
+		t.Fatalf("Failed to start bedrock: %v", err)
+	}
+	defer br.Stop()
+
+	if !br.IsReadOnly() {
+		t.Error("Expected bedrock to be read-only")
+	}
+
+	// Write should fail
+	if err := br.Write("test.txt", []byte("test")); err != ErrReadOnly {
+		t.Errorf("Expected ErrReadOnly, got %v", err)
+	}
+}
+
+func TestUnixBedrock_PathValidation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bedrock-test-path-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	br, err := NewUnixBedrock(UnixBedrockConfig{
+		Name: "test",
+		Path: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bedrock: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := br.Start(ctx); err != nil {
+		t.Fatalf("Failed to start bedrock: %v", err)
+	}
+	defer br.Stop()
+
+	// Path traversal should fail
+	testCases := []string{
+		"../escape",
+		"foo/../../../etc/passwd",
+		"/absolute/path",
+	}
+
+	for _, path := range testCases {
+		if err := br.Write(path, []byte("test")); err != ErrInvalidPath {
+			t.Errorf("Expected ErrInvalidPath for path '%s', got %v", path, err)
+		}
+	}
+}
+
+func TestUnixBedrock_NestedDirectories(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bedrock-test-nested-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	br, err := NewUnixBedrock(UnixBedrockConfig{
+		Name: "test",
+		Path: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bedrock: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := br.Start(ctx); err != nil {
+		t.Fatalf("Failed to start bedrock: %v", err)
+	}
+	defer br.Stop()
+
+	// Write to nested path (should create directories)
+	nestedPath := "a/b/c/test.txt"
+	if err := br.Write(nestedPath, []byte("nested content")); err != nil {
+		t.Fatalf("Failed to write nested file: %v", err)
+	}
+
+	// Verify we can read it
+	content, err := br.Read(nestedPath)
+	if err != nil {
+		t.Fatalf("Failed to read nested file: %v", err)
+	}
+	if string(content) != "nested content" {
+		t.Errorf("Unexpected content: %s", content)
+	}
+
+	// Verify tree shows nested structure
+	tree, err := br.Tree(10)
+	if err != nil {
+		t.Fatalf("Failed to get tree: %v", err)
+	}
+	t.Logf("Tree:\n%s", tree)
+}
+
+func TestUnixBedrock_Move(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bedrock-test-move-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	br, err := NewUnixBedrock(UnixBedrockConfig{
+		Name: "test",
+		Path: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bedrock: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := br.Start(ctx); err != nil {
+		t.Fatalf("Failed to start bedrock: %v", err)
+	}
+	defer br.Stop()
+
+	// Create a file
+	if err := br.Write("original.txt", []byte("test content")); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	// Move it
+	if err := br.Move("original.txt", "moved.txt"); err != nil {
+		t.Fatalf("Failed to move file: %v", err)
+	}
+
+	// Verify original is gone
+	if _, err := br.Read("original.txt"); err != ErrNotFound {
+		t.Error("Expected original file to not exist")
+	}
+
+	// Verify new location has content
+	content, err := br.Read("moved.txt")
+	if err != nil {
+		t.Fatalf("Failed to read moved file: %v", err)
+	}
+	if string(content) != "test content" {
+		t.Errorf("Unexpected content: %s", content)
+	}
+}
+
+func TestUnixBedrock_Watch(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bedrock-test-watch-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	br, err := NewUnixBedrock(UnixBedrockConfig{
+		Name: "test",
+		Path: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bedrock: %v", err)
+	}
+
+	// Set up event channel
+	eventChan := make(chan BedrockEvent, 10)
+	if err := br.Watch(context.Background(), func(e BedrockEvent) {
+		eventChan <- e
+	}); err != nil {
+		t.Fatalf("Failed to set up watch: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := br.Start(ctx); err != nil {
+		t.Fatalf("Failed to start bedrock: %v", err)
+	}
+	defer br.Stop()
+
+	// Wait for mounted event
+	select {
+	case e := <-eventChan:
+		if e.Type != BedrockEventMounted {
+			t.Errorf("Expected mounted event, got %s", e.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Timeout waiting for mounted event")
+	}
+
+	// Create a file directly (not through bedrock API to trigger fsnotify)
+	testFile := filepath.Join(tmpDir, "watch-test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Wait for create event
+	select {
+	case e := <-eventChan:
+		if e.Type != BedrockEventFileCreated {
+			t.Errorf("Expected file.created event, got %s", e.Type)
+		}
+		if e.Path != "watch-test.txt" {
+			t.Errorf("Expected path 'watch-test.txt', got '%s'", e.Path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Timeout waiting for file created event")
+	}
+}
+
+func TestUnixBedrock_Manifest(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bedrock-test-manifest-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	br, err := NewUnixBedrock(UnixBedrockConfig{
+		Name: "test-manifest",
+		Path: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bedrock: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := br.Start(ctx); err != nil {
+		t.Fatalf("Failed to start bedrock: %v", err)
+	}
+	defer br.Stop()
+
+	// Create some files
+	for i := 0; i < 5; i++ {
+		filename := filepath.Join("test", "file"+string(rune('a'+i))+".txt")
+		if err := br.Write(filename, []byte("content")); err != nil {
+			t.Fatalf("Failed to write file: %v", err)
+		}
+	}
+
+	// Get manifest
+	manifest, err := br.Manifest()
+	if err != nil {
+		t.Fatalf("Failed to get manifest: %v", err)
+	}
+
+	if manifest.Name != "test-manifest" {
+		t.Errorf("Expected name 'test-manifest', got '%s'", manifest.Name)
+	}
+	if manifest.Type != "unix" {
+		t.Errorf("Expected type 'unix', got '%s'", manifest.Type)
+	}
+	if manifest.FileCount != 5 {
+		t.Errorf("Expected 5 files, got %d", manifest.FileCount)
+	}
+	if manifest.TotalSize != 5*7 { // 5 files * len("content")
+		t.Errorf("Expected total size %d, got %d", 5*7, manifest.TotalSize)
+	}
+}
+
+func TestBedrockConfig_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "valid unix bedrock",
+			config: Config{
+				Bedrocks: map[string]BedrockConfig{
+					"scratch": {Type: "unix", Path: "/tmp/scratch"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid git bedrock",
+			config: Config{
+				Bedrocks: map[string]BedrockConfig{
+					"docs": {Type: "git", Path: "/repos/docs", WriteMode: "commit"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid git bedrock with PR mode",
+			config: Config{
+				Bedrocks: map[string]BedrockConfig{
+					"docs": {
+						Type:      "git",
+						Path:      "/repos/docs",
+						WriteMode: "pull_request",
+						PRConfig: &BedrockPRConfig{
+							BaseBranch:   "main",
+							BranchPrefix: "nim/",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing type",
+			config: Config{
+				Bedrocks: map[string]BedrockConfig{
+					"invalid": {Path: "/tmp"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unix missing path",
+			config: Config{
+				Bedrocks: map[string]BedrockConfig{
+					"invalid": {Type: "unix"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "git invalid write mode",
+			config: Config{
+				Bedrocks: map[string]BedrockConfig{
+					"invalid": {Type: "git", Path: "/tmp", WriteMode: "invalid"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown type",
+			config: Config{
+				Bedrocks: map[string]BedrockConfig{
+					"invalid": {Type: "unknown", Path: "/tmp"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBedrockLock_IsExpired(t *testing.T) {
+	tests := []struct {
+		name    string
+		lock    BedrockLock
+		expired bool
+	}{
+		{
+			name: "pending PR never expires",
+			lock: BedrockLock{
+				Type:     LockTypePendingPR,
+				Acquired: time.Now().Add(-24 * time.Hour),
+				TTL:      30,
+			},
+			expired: false,
+		},
+		{
+			name: "write lock not expired",
+			lock: BedrockLock{
+				Type:     LockTypeWrite,
+				Acquired: time.Now(),
+				TTL:      30,
+			},
+			expired: false,
+		},
+		{
+			name: "write lock expired by TTL",
+			lock: BedrockLock{
+				Type:     LockTypeWrite,
+				Acquired: time.Now().Add(-60 * time.Second),
+				TTL:      30,
+			},
+			expired: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.lock.IsExpired(); got != tt.expired {
+				t.Errorf("IsExpired() = %v, want %v", got, tt.expired)
+			}
+		})
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{0, "0B"},
+		{100, "100B"},
+		{1024, "1.0KB"},
+		{1536, "1.5KB"},
+		{1024 * 1024, "1.0MB"},
+		{1024 * 1024 * 1024, "1.0GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := formatSize(tt.bytes)
+			if got != tt.expected {
+				t.Errorf("formatSize(%d) = %s, want %s", tt.bytes, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/runtime/bedrock_unix.go
+++ b/pkg/runtime/bedrock_unix.go
@@ -1,0 +1,726 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"log"
+	"mime"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// UnixBedrock provides direct filesystem access as a bedrock.
+// It uses fsnotify for watching file changes on Linux, macOS, and BSD.
+type UnixBedrock struct {
+	name     string
+	root     string
+	readonly bool
+
+	watcher *fsnotify.Watcher
+	handler func(BedrockEvent)
+
+	mu       sync.RWMutex
+	running  bool
+	cancelFn context.CancelFunc
+}
+
+// UnixBedrockConfig configures a Unix bedrock.
+type UnixBedrockConfig struct {
+	Name     string `yaml:"name"`
+	Path     string `yaml:"path"`
+	ReadOnly bool   `yaml:"readonly,omitempty"`
+}
+
+// NewUnixBedrock creates a new Unix bedrock.
+func NewUnixBedrock(cfg UnixBedrockConfig) (*UnixBedrock, error) {
+	// Validate and resolve path
+	absPath, err := filepath.Abs(cfg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	// Check path exists and is a directory
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Try to create it
+			if err := os.MkdirAll(absPath, 0755); err != nil {
+				return nil, fmt.Errorf("path does not exist and could not be created: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to stat path: %w", err)
+		}
+	} else if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", absPath)
+	}
+
+	return &UnixBedrock{
+		name:     cfg.Name,
+		root:     absPath,
+		readonly: cfg.ReadOnly,
+	}, nil
+}
+
+// Name returns the bedrock name.
+func (b *UnixBedrock) Name() string {
+	return b.name
+}
+
+// Type returns "unix".
+func (b *UnixBedrock) Type() string {
+	return "unix"
+}
+
+// Root returns the root path.
+func (b *UnixBedrock) Root() string {
+	return b.root
+}
+
+// Start starts the bedrock and begins watching for changes.
+func (b *UnixBedrock) Start(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.running {
+		return fmt.Errorf("bedrock already running")
+	}
+
+	// Create watcher
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create watcher: %w", err)
+	}
+	b.watcher = watcher
+
+	// Add all directories recursively
+	err = filepath.WalkDir(b.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // Skip errors
+		}
+		if d.IsDir() {
+			if err := watcher.Add(path); err != nil {
+				log.Printf("[Bedrock:%s] Warning: failed to watch %s: %v", b.name, path, err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		watcher.Close()
+		return fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	// Create cancellable context
+	ctx, cancel := context.WithCancel(ctx)
+	b.cancelFn = cancel
+
+	// Start watching in background
+	go b.watchLoop(ctx)
+
+	b.running = true
+	log.Printf("[Bedrock:%s] Started watching %s", b.name, b.root)
+
+	// Emit mounted event
+	if b.handler != nil {
+		b.handler(BedrockEvent{
+			Bedrock:   b.name,
+			Type:      BedrockEventMounted,
+			Timestamp: time.Now(),
+		})
+	}
+
+	return nil
+}
+
+// Stop stops the bedrock.
+func (b *UnixBedrock) Stop() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !b.running {
+		return nil
+	}
+
+	if b.cancelFn != nil {
+		b.cancelFn()
+	}
+
+	if b.watcher != nil {
+		b.watcher.Close()
+		b.watcher = nil
+	}
+
+	b.running = false
+	log.Printf("[Bedrock:%s] Stopped", b.name)
+
+	// Emit unmounted event
+	if b.handler != nil {
+		b.handler(BedrockEvent{
+			Bedrock:   b.name,
+			Type:      BedrockEventUnmounted,
+			Timestamp: time.Now(),
+		})
+	}
+
+	return nil
+}
+
+// watchLoop handles file system events.
+func (b *UnixBedrock) watchLoop(ctx context.Context) {
+	for {
+		b.mu.RLock()
+		watcher := b.watcher
+		b.mu.RUnlock()
+
+		if watcher == nil {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			b.handleFSEvent(event)
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("[Bedrock:%s] Watch error: %v", b.name, err)
+		}
+	}
+}
+
+// handleFSEvent converts fsnotify events to bedrock events.
+func (b *UnixBedrock) handleFSEvent(event fsnotify.Event) {
+	if b.handler == nil {
+		return
+	}
+
+	// Get relative path
+	relPath, err := filepath.Rel(b.root, event.Name)
+	if err != nil {
+		relPath = event.Name
+	}
+
+	// Skip hidden files and common ignore patterns
+	if shouldIgnore(relPath) {
+		return
+	}
+
+	var eventType BedrockEventType
+	var fileInfo *FileInfo
+
+	switch {
+	case event.Op&fsnotify.Create == fsnotify.Create:
+		eventType = BedrockEventFileCreated
+		fileInfo, _ = b.stat(relPath)
+
+		// If it's a new directory, add it to the watcher
+		if fileInfo != nil && fileInfo.IsDir {
+			b.mu.RLock()
+			if b.watcher != nil {
+				_ = b.watcher.Add(event.Name)
+			}
+			b.mu.RUnlock()
+		}
+
+	case event.Op&fsnotify.Write == fsnotify.Write:
+		eventType = BedrockEventFileModified
+		fileInfo, _ = b.stat(relPath)
+
+	case event.Op&fsnotify.Remove == fsnotify.Remove:
+		eventType = BedrockEventFileDeleted
+
+	case event.Op&fsnotify.Rename == fsnotify.Rename:
+		eventType = BedrockEventFileDeleted // Rename is essentially delete + create
+
+	default:
+		return
+	}
+
+	b.handler(BedrockEvent{
+		Bedrock:   b.name,
+		Type:      eventType,
+		Path:      relPath,
+		Timestamp: time.Now(),
+		FileInfo:  fileInfo,
+	})
+}
+
+// List returns files in the given path.
+func (b *UnixBedrock) List(path string) ([]FileInfo, error) {
+	b.mu.RLock()
+	running := b.running
+	b.mu.RUnlock()
+
+	if !running {
+		return nil, ErrBedrockStopped
+	}
+
+	fullPath := filepath.Join(b.root, path)
+
+	entries, err := os.ReadDir(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	var files []FileInfo
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		entryPath := filepath.Join(path, entry.Name())
+		files = append(files, FileInfo{
+			Path:     entryPath,
+			Name:     entry.Name(),
+			Size:     info.Size(),
+			Modified: info.ModTime(),
+			IsDir:    entry.IsDir(),
+			MimeType: getMimeType(entry.Name()),
+		})
+	}
+
+	return files, nil
+}
+
+// Read reads a file's contents.
+func (b *UnixBedrock) Read(path string) ([]byte, error) {
+	b.mu.RLock()
+	running := b.running
+	b.mu.RUnlock()
+
+	if !running {
+		return nil, ErrBedrockStopped
+	}
+
+	// Validate path
+	if err := validatePath(path); err != nil {
+		return nil, err
+	}
+
+	fullPath := filepath.Join(b.root, path)
+
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return data, nil
+}
+
+// Stat returns file metadata.
+func (b *UnixBedrock) Stat(path string) (*FileInfo, error) {
+	b.mu.RLock()
+	running := b.running
+	b.mu.RUnlock()
+
+	if !running {
+		return nil, ErrBedrockStopped
+	}
+
+	return b.stat(path)
+}
+
+// stat is the internal stat implementation.
+func (b *UnixBedrock) stat(path string) (*FileInfo, error) {
+	fullPath := filepath.Join(b.root, path)
+
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	fileInfo := &FileInfo{
+		Path:     path,
+		Name:     info.Name(),
+		Size:     info.Size(),
+		Modified: info.ModTime(),
+		IsDir:    info.IsDir(),
+		MimeType: getMimeType(info.Name()),
+	}
+
+	// Compute content hash for files (not directories)
+	if !info.IsDir() && info.Size() < 10*1024*1024 { // Only for files < 10MB
+		if data, err := os.ReadFile(fullPath); err == nil {
+			hash := sha256.Sum256(data)
+			fileInfo.ContentHash = "sha256:" + hex.EncodeToString(hash[:])
+		}
+	}
+
+	return fileInfo, nil
+}
+
+// Tree returns a text representation of the directory tree.
+func (b *UnixBedrock) Tree(maxDepth int) (string, error) {
+	b.mu.RLock()
+	running := b.running
+	b.mu.RUnlock()
+
+	if !running {
+		return "", ErrBedrockStopped
+	}
+
+	if maxDepth <= 0 {
+		maxDepth = 10 // Default max depth
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s/ (mounted: %s, type: %s)\n", b.name, b.root, b.Type()))
+
+	var fileCount, dirCount int
+	var totalSize int64
+
+	err := b.buildTree(&buf, "", 0, maxDepth, &fileCount, &dirCount, &totalSize)
+	if err != nil {
+		return "", err
+	}
+
+	buf.WriteString(fmt.Sprintf("\n%d files, %d directories, %s total\n",
+		fileCount, dirCount, formatSize(totalSize)))
+
+	return buf.String(), nil
+}
+
+// buildTree recursively builds the tree representation.
+func (b *UnixBedrock) buildTree(buf *bytes.Buffer, path string, depth, maxDepth int, fileCount, dirCount *int, totalSize *int64) error {
+	if depth >= maxDepth {
+		return nil
+	}
+
+	fullPath := filepath.Join(b.root, path)
+	entries, err := os.ReadDir(fullPath)
+	if err != nil {
+		return err
+	}
+
+	for i, entry := range entries {
+		// Skip hidden files
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		entryPath := filepath.Join(path, entry.Name())
+		isLast := i == len(entries)-1
+
+		// Build prefix
+		prefix := strings.Repeat("│   ", depth)
+		connector := "├── "
+		if isLast {
+			connector = "└── "
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		if entry.IsDir() {
+			*dirCount++
+			buf.WriteString(fmt.Sprintf("%s%s%s/\n", prefix, connector, entry.Name()))
+			b.buildTree(buf, entryPath, depth+1, maxDepth, fileCount, dirCount, totalSize)
+		} else {
+			*fileCount++
+			*totalSize += info.Size()
+			buf.WriteString(fmt.Sprintf("%s%s%s (%s, modified: %s)\n",
+				prefix, connector, entry.Name(),
+				formatSize(info.Size()),
+				info.ModTime().Format("2006-01-02")))
+		}
+	}
+
+	return nil
+}
+
+// Write writes content to a file.
+func (b *UnixBedrock) Write(path string, content []byte) error {
+	b.mu.RLock()
+	running := b.running
+	readonly := b.readonly
+	b.mu.RUnlock()
+
+	if !running {
+		return ErrBedrockStopped
+	}
+	if readonly {
+		return ErrReadOnly
+	}
+
+	// Validate path
+	if err := validatePath(path); err != nil {
+		return err
+	}
+
+	fullPath := filepath.Join(b.root, path)
+
+	// Ensure parent directory exists
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Write file
+	if err := os.WriteFile(fullPath, content, 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	log.Printf("[Bedrock:%s] Wrote %s (%d bytes)", b.name, path, len(content))
+	return nil
+}
+
+// Delete removes a file or directory.
+func (b *UnixBedrock) Delete(path string) error {
+	b.mu.RLock()
+	running := b.running
+	readonly := b.readonly
+	b.mu.RUnlock()
+
+	if !running {
+		return ErrBedrockStopped
+	}
+	if readonly {
+		return ErrReadOnly
+	}
+
+	// Validate path
+	if err := validatePath(path); err != nil {
+		return err
+	}
+
+	fullPath := filepath.Join(b.root, path)
+
+	// Check if exists
+	if _, err := os.Stat(fullPath); err != nil {
+		if os.IsNotExist(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("failed to stat: %w", err)
+	}
+
+	if err := os.RemoveAll(fullPath); err != nil {
+		return fmt.Errorf("failed to delete: %w", err)
+	}
+
+	log.Printf("[Bedrock:%s] Deleted %s", b.name, path)
+	return nil
+}
+
+// Move moves a file or directory.
+func (b *UnixBedrock) Move(from, to string) error {
+	b.mu.RLock()
+	running := b.running
+	readonly := b.readonly
+	b.mu.RUnlock()
+
+	if !running {
+		return ErrBedrockStopped
+	}
+	if readonly {
+		return ErrReadOnly
+	}
+
+	// Validate paths
+	if err := validatePath(from); err != nil {
+		return fmt.Errorf("invalid source path: %w", err)
+	}
+	if err := validatePath(to); err != nil {
+		return fmt.Errorf("invalid destination path: %w", err)
+	}
+
+	fromPath := filepath.Join(b.root, from)
+	toPath := filepath.Join(b.root, to)
+
+	// Check source exists
+	if _, err := os.Stat(fromPath); err != nil {
+		if os.IsNotExist(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("failed to stat source: %w", err)
+	}
+
+	// Ensure destination parent exists
+	if err := os.MkdirAll(filepath.Dir(toPath), 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	if err := os.Rename(fromPath, toPath); err != nil {
+		return fmt.Errorf("failed to move: %w", err)
+	}
+
+	log.Printf("[Bedrock:%s] Moved %s -> %s", b.name, from, to)
+	return nil
+}
+
+// IsReadOnly returns whether the bedrock is read-only.
+func (b *UnixBedrock) IsReadOnly() bool {
+	return b.readonly
+}
+
+// SupportsWatch returns true as Unix bedrocks support fsnotify.
+func (b *UnixBedrock) SupportsWatch() bool {
+	return true
+}
+
+// Watch sets the event handler for file changes.
+func (b *UnixBedrock) Watch(ctx context.Context, handler func(BedrockEvent)) error {
+	b.mu.Lock()
+	b.handler = handler
+	b.mu.Unlock()
+	return nil
+}
+
+// Manifest returns the bedrock manifest.
+func (b *UnixBedrock) Manifest() (*BedrockManifest, error) {
+	b.mu.RLock()
+	running := b.running
+	b.mu.RUnlock()
+
+	if !running {
+		return nil, ErrBedrockStopped
+	}
+
+	var fileCount int
+	var totalSize int64
+
+	err := filepath.WalkDir(b.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			fileCount++
+			if info, err := d.Info(); err == nil {
+				totalSize += info.Size()
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	return &BedrockManifest{
+		Name:      b.name,
+		Type:      b.Type(),
+		Root:      b.root,
+		FileCount: fileCount,
+		TotalSize: totalSize,
+		LastScan:  time.Now(),
+	}, nil
+}
+
+// Helper functions
+
+// validatePath ensures the path is safe (no path traversal).
+func validatePath(path string) error {
+	if path == "" {
+		return ErrInvalidPath
+	}
+
+	// Clean and check for path traversal
+	clean := filepath.Clean(path)
+	if strings.HasPrefix(clean, "..") || strings.HasPrefix(clean, "/") {
+		return ErrInvalidPath
+	}
+
+	return nil
+}
+
+// shouldIgnore returns true if the path should be ignored.
+func shouldIgnore(path string) bool {
+	name := filepath.Base(path)
+
+	// Hidden files
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+
+	// Common ignore patterns
+	ignorePatterns := []string{
+		"node_modules",
+		"__pycache__",
+		".git",
+		".svn",
+		".hg",
+		"vendor",
+		"target",
+		".idea",
+		".vscode",
+	}
+
+	for _, pattern := range ignorePatterns {
+		if name == pattern || strings.Contains(path, "/"+pattern+"/") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getMimeType returns the MIME type for a file based on extension.
+func getMimeType(name string) string {
+	ext := filepath.Ext(name)
+	if ext == "" {
+		return "application/octet-stream"
+	}
+
+	mimeType := mime.TypeByExtension(ext)
+	if mimeType == "" {
+		// Common types not in stdlib
+		switch ext {
+		case ".md":
+			return "text/markdown"
+		case ".yaml", ".yml":
+			return "text/yaml"
+		case ".go":
+			return "text/x-go"
+		case ".lua":
+			return "text/x-lua"
+		case ".ts":
+			return "text/typescript"
+		case ".tsx":
+			return "text/typescript-jsx"
+		case ".jsx":
+			return "text/javascript-jsx"
+		default:
+			return "application/octet-stream"
+		}
+	}
+	return mimeType
+}
+
+// formatSize formats bytes as human-readable string.
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%dB", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}


### PR DESCRIPTION
Bedrock provides persistent storage beneath Soil (the ephemeral KV store). This enables cluster recovery - Bedrock is always the source of truth, and Soil can be rebuilt from it.

Core implementation:
- Bedrock interface with lifecycle, read/write ops, and capabilities
- UnixBedrock: filesystem access with fsnotify watching
- GitBedrockImpl: git repo with commit and PR workflow support
- Forest integration: bedrocks start/stop with forest lifecycle
- Config support: YAML configuration for bedrocks
- Comprehensive test suite

Remaining for Phase 2:
- BedrockReadTreehouse for Soil indexing
- BedrockWriteTreehouse with distributed locking
- Cluster recovery from bedrock state

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark with an `x` all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] CI/CD changes

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linting passes (`make lint`)
- [ ] Code is formatted (`make fmt`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

<!-- Link to related issues -->

Closes #(issue number)

## Additional Context

<!-- Add any other context about the PR here -->
